### PR TITLE
Remove comparison to copyright and patent law

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,9 +128,7 @@
 
 		    <p>Trademark rights are not an absolute right to use a word in any context, but rather are limited to particular goods or services when used in commerce. That is why EAGLE pencils and EAGLE nuts can co-exist, and why, while there is a famous brand called ORANGE, we can all still talk about oranges.</p>
 
-		     <p>A trademark is often called “intellectual property” but is distinct from other rights typically called “intellectual property” &ndash; copyrights and patents. Copyright and patent law protect the proprietary interests of the creator, but trademarks protect the consumer.</p>
-
-		    <p>Trademark law prohibits others from using your trademark on inauthentic, or counterfeit, goods. In this way a trademark is a "stamp of approval" that the consumer can rely on when they are purchasing or downloading your product. But trademark protection goes beyond counterfeits, extending to other ways the consumer might become confused, for example, when two names are similar enough to be mistaken for each other, or when your trademark is used by someone to suggest they are associated with you when they are not.</p>
+            <p>Trademark law protects consumers by prohibiting others from using your trademark on inauthentic, or counterfeit, goods. In this way a trademark is a "stamp of approval" that the consumer can rely on when they are purchasing or downloading your product. But trademark protection goes beyond counterfeits, extending to other ways the consumer might become confused, for example, when two names are similar enough to be mistaken for each other, or when your trademark is used by someone to suggest they are associated with you when they are not.</p>
 
 		     <p>There are several aspects of how trademarks work you should consider. It starts with <a href="#choosing_name">choosing a good name</a>. Additional benefits may be available if you <a href="#registration">register your name</a> with various governments. Finally, what happens when <a href="#infringement">someone else uses your mark without your permission</a>, or uses a confusingly similar mark?</p>
 


### PR DESCRIPTION
The reference to the purpose of copyright and patent law was not really
relevant to the discussion of trademarks, nor was it entirely accurate
(in the U.S. copyright and patent are ostensibly intended to serve the
public good as well).