### PR TITLE
Deployment scripts for FSFE infrastructure

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,26 @@
+---
+kind: pipeline
+name: default
+
+steps:
+- name: deploy
+  image: docker/compose:1.24.0
+  commands:
+  - docker-compose up --build -d
+  volumes:
+  - name: dockersock
+    path: /var/run/docker.sock
+  when:
+    branch:
+    - master
+    event:
+    - push
+    - tag
+    - deployment
+
+volumes:
+- name: dockersock
+  host:
+    path: /var/run/docker.sock
+
+...

--- a/000-default.conf
+++ b/000-default.conf
@@ -1,0 +1,22 @@
+<VirtualHost *:80>
+  ServerName www.fossmarks.org
+  Redirect permanent / https://fossmarks.org/
+</VirtualHost>
+
+<VirtualHost *:80>
+  ServerName fossmarks.org
+
+  ServerAdmin contact@fsfe.org
+  DocumentRoot /var/www/html
+
+  ErrorLog ${APACHE_LOG_DIR}/error.log
+  CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+<Directory /var/www/html/>
+  Options FollowSymLinks Includes
+  AllowOverride All
+  Order allow,deny
+  Allow from all
+</Directory>
+
+</VirtualHost>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM php:7-apache
+
+ENV HUGO_VERSION 0.66.0
+ENV HUGO_BINARY hugo_${HUGO_VERSION}_Linux-64bit.deb
+
+ADD https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_BINARY} /tmp/hugo.deb
+RUN dpkg -i /tmp/hugo.deb && \
+    rm /tmp/hugo.deb
+
+COPY . /tmp/fossmarks-website
+
+RUN hugo -s /tmp/fossmarks-website -d /var/www/html
+
+COPY 000-default.conf /etc/apache2/sites-enabled/
+
+RUN a2enmod rewrite headers expires
+
+CMD apache2-foreground

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # [FOSSmarks](http://fossmarks.org)
 
+[![Build Status](https://drone.fsfe.org/api/badges/fsfe-system-hackers/FOSSmarks/status.svg)](https://drone.fsfe.org/fsfe-system-hackers/FOSSmarks)
+
+
 A practical guide to understanding trademarks in the context of Free and Open Source Software projects.
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  fossmarks:
+    container_name: fossmarks
+    build: .
+    image: fossmarks
+    restart: always
+    expose:
+      - 80
+    environment:
+      - VIRTUAL_HOST=www.fossmarks.org,fossmarks.org
+      - LETSENCRYPT_HOST=www.fossmarks.org,fossmarks.org
+      - LETSENCRYPT_EMAIL=contact@fsfe.org
+
+  # Connect the container which exposes the service to the 'bridge' network as
+  # this is where the reverse proxy is
+  connect-bridge:
+    image: docker:dind
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - fossmarks
+    command: /bin/sh -c 'docker network connect bridge fossmarks'


### PR DESCRIPTION
This PR should prepare everything for deployment of FSFE's Docker infrastructure. This repo is mirrored to here from where it is deployed: https://git.fsfe.org/fsfe-system-hackers/FOSSmarks

Of course, the IP would have to change as well in order to complete everything. After the IP change, we perhaps have to trigger another build in order to make Let's Encrypt issue a certificate.