### PR TITLE
prepare migration to rootless daemon on cont1.noris

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,30 +3,28 @@ kind: pipeline
 name: default
 
 steps:
-- name: hugo
-  image: plugins/hugo
-  settings:
-    source: site
-    validate: true
+  - name: hugo
+    image: plugins/hugo
+    settings:
+      source: site
+      validate: true
 
-- name: deploy
-  image: docker/compose:1.29.1
-  commands:
-  - docker-compose -p fossmarks up --build -d
-  volumes:
-  - name: dockersock
-    path: /var/run/docker.sock
-  when:
-    branch:
-    - master
-    event:
-    - push
-    - tag
-    - deployment
+  - name: deploy
+    image: docker/compose:1.29.2
+    commands:
+      - docker-compose -p fossmarks up --build -d
+    volumes:
+      - name: dockersock
+        path: /run/user/1001/docker.sock
+    when:
+      branch:
+        - master
+      event:
+        - push
+        - tag
+        - deployment
 
 volumes:
-- name: dockersock
-  host:
-    path: /var/run/docker.sock
-
-...
+  - name: dockersock
+    host:
+      path: /run/user/1001/docker.sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,6 +24,9 @@ steps:
         - tag
         - deployment
 
+node:
+  cont1: noris
+
 volumes:
   - name: dockersock
     host:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-version: '3'
+---
+version: "3"
 services:
   fossmarks:
     container_name: fossmarks
@@ -16,7 +17,7 @@ services:
   connect-bridge:
     image: docker:dind
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /run/user/1001/docker.sock:/var/run/docker.sock
     depends_on:
       - fossmarks
     command: /bin/sh -c 'docker network connect bridge fossmarks'


### PR DESCRIPTION
the only thing left to do is changing the DNS entries for `fossmarks.org` to our new container host:

cont1.noris.fsfeurope.org
213.95.165.52
2001:780:215:1::52

After merging our CI/CD system should do the rest. 